### PR TITLE
Use correct header in plugin description.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "wordpress/wp-plugin-dependencies",
-  "description": "Parses 'Requires Plugin' header, add plugin install dependencies tab, and information about dependencies.",
+  "description": "Parses 'Requires Plugins' header, add plugin install dependencies tab, and information about dependencies.",
   "type": "wordpress-plugin",
   "license": "MIT",
   "authors": [

--- a/plugin.php
+++ b/plugin.php
@@ -11,7 +11,7 @@
 /**
  * Plugin Name: Plugin Dependencies
  * Plugin URI:  https://github.com/WordPress/wp-plugin-dependencies
- * Description: Parses 'Requires Plugin' header, add plugin install dependencies tab, and information about dependencies.
+ * Description: Parses 'Requires Plugins' header, add plugin install dependencies tab, and information about dependencies.
  * Author: Andy Fragen, Colin Stewart
  * Version: 0.16.2
  * License: MIT


### PR DESCRIPTION
Minor text tweak. The plugin description states "Parses 'Requires Plugin' header", which is not the correct header. This changes the text to be "Parses 'Requires Plugins' header".