### PR TITLE
Tests: Add tests for `::get_dependency_filepaths()`.

### DIFF
--- a/tests/phpunit/tests/admin/wpPluginDependencies.php
+++ b/tests/phpunit/tests/admin/wpPluginDependencies.php
@@ -395,4 +395,107 @@ class Tests_Admin_WpPluginDependencies extends WP_UnitTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Tests that dependency filepaths are retrieved correctly.
+	 *
+	 * @covers WP_Plugin_Dependencies::get_dependency_filepaths
+	 *
+	 * @dataProvider data_get_dependency_filepaths
+	 *
+	 * @param string[] $slugs    An array of slugs.
+	 * @param string[] $plugins  An array of plugin paths.
+	 * @param array    $expected An array of expected filepath results.
+	 */
+	public function test_get_dependency_filepaths( $slugs, $plugins, $expected ) {
+		$dependencies       = new WP_Plugin_Dependencies();
+		$get_filepaths      = $this->make_method_accessible( $dependencies, 'get_dependency_filepaths' );
+		$dependency_slugs   = $this->make_prop_accessible( $dependencies, 'slugs' );
+		$dependency_plugins = $this->make_prop_accessible( $dependencies, 'plugins' );
+
+		$dependency_slugs->setValue( $dependencies, $slugs );
+		$dependency_plugins->setValue( $dependencies, array_flip( $plugins ) );
+
+		$this->assertSame( $expected, $get_filepaths->invoke( $dependencies ) );
+	}
+
+	/**
+	 * Data provider for test_get_dependency_filepaths().
+	 *
+	 * @return array
+	 */
+	public function data_get_dependency_filepaths() {
+		return array(
+			'no slugs'                                     => array(
+				'slugs'    => array(),
+				'plugins'  => array( 'plugin1/plugin1.php', 'plugin2/plugin2.php' ),
+				'expected' => array(),
+			),
+			'no plugins'                                   => array(
+				'slugs'    => array( 'plugin1', 'plugin2' ),
+				'plugins'  => array(),
+				'expected' => array(),
+			),
+			'a plugin that starts with slug/'              => array(
+				'slugs'    => array( 'plugin1' ),
+				'plugins'  => array( 'plugin1-pro/plugin1.php' ),
+				'expected' => array( 'plugin1' => false ),
+			),
+			'a plugin that ends with slug/'                => array(
+				'slugs'    => array( 'plugin1' ),
+				'plugins'  => array( 'addon-for-plugin1/plugin1.php' ),
+				'expected' => array( 'plugin1' => false ),
+			),
+			'a plugin that does not exist'                 => array(
+				'slugs'    => array( 'plugin2' ),
+				'plugins'  => array( 'plugin1/plugin1.php' ),
+				'expected' => array( 'plugin2' => false ),
+			),
+			'a plugin that exists'                         => array(
+				'slugs'    => array( 'plugin1' ),
+				'plugins'  => array( 'plugin1/plugin1.php' ),
+				'expected' => array( 'plugin1' => 'plugin1/plugin1.php' ),
+			),
+			'two plugins that exist'                       => array(
+				'slugs'    => array( 'plugin1', 'plugin2' ),
+				'plugins'  => array( 'plugin1/plugin1.php', 'plugin2/plugin2.php' ),
+				'expected' => array(
+					'plugin1' => 'plugin1/plugin1.php',
+					'plugin2' => 'plugin2/plugin2.php',
+				),
+			),
+			'two plugins that exist (reversed slug order)' => array(
+				'slugs'    => array( 'plugin2', 'plugin1' ),
+				'plugins'  => array( 'plugin1/plugin1.php', 'plugin2/plugin2.php' ),
+				'expected' => array(
+					'plugin2' => 'plugin2/plugin2.php',
+					'plugin1' => 'plugin1/plugin1.php',
+				),
+			),
+			'two plugins, first exists, second does not exist' => array(
+				'slugs'    => array( 'plugin1', 'plugin2' ),
+				'plugins'  => array( 'plugin1/plugin1.php', 'plugin3/plugin3.php' ),
+				'expected' => array(
+					'plugin1' => 'plugin1/plugin1.php',
+					'plugin2' => false,
+				),
+			),
+			'two plugins, first does not exist, second does exist' => array(
+				'slugs'    => array( 'plugin1', 'plugin2' ),
+				'plugins'  => array( 'plugin2/plugin2.php', 'plugin3/plugin3.php' ),
+				'expected' => array(
+					'plugin1' => false,
+					'plugin2' => 'plugin2/plugin2.php',
+				),
+			),
+			'two plugins that do not exist'                       => array(
+				'slugs'    => array( 'plugin1', 'plugin2' ),
+				'plugins'  => array( 'plugin3/plugin3.php', 'plugin4/plugin4.php' ),
+				'expected' => array(
+					'plugin1' => false,
+					'plugin2' => false,
+				),
+			),
+		);
+	}
 }


### PR DESCRIPTION
This PR introduces tests for `WP_Plugin_Dependencies::get_dependency_filepaths()`.

- [x] Line coverage: 100% (8/8)
- [x] Branch coverage: 100% (9/9)
- [ ] Path coverage: 66.67% (4/6)


