### PR TITLE
Various improvements to `::cannot_activate_unmet_dependencies()`.

### DIFF
--- a/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -460,7 +460,7 @@ class WP_Plugin_Dependencies {
 			if ( ! $dependencies[ $plugin_dependency ] || is_plugin_inactive( $dependencies[ $plugin_dependency ] ) ) {
 				$actions['activate']     = __( 'Cannot Activate' );
 				$actions['dependencies'] = sprintf(
-				/* translators: 1: opening tag link to Dependencies tab 2: closing tag */
+					/* translators: 1: Opening link tag to the Dependencies tab, 2: Closing link tag. */
 					__( '%1$sDependencies%2$s' ),
 					'<a href=' . esc_url( network_admin_url( 'plugin-install.php?tab=dependencies' ) ) . '>',
 					'</a>'

--- a/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -442,7 +442,7 @@ class WP_Plugin_Dependencies {
 	 * @param array  $actions     Plugin action links.
 	 * @param string $plugin_file File name.
 	 *
-	 * @return array
+	 * @return array Plugin action links after checking for unmet dependencies.
 	 */
 	public function cannot_activate_unmet_dependencies( $actions, $plugin_file ) {
 		$dependencies          = $this->get_dependency_filepaths();

--- a/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -445,25 +445,28 @@ class WP_Plugin_Dependencies {
 	 * @return array
 	 */
 	public function cannot_activate_unmet_dependencies( $actions, $plugin_file ) {
-		$dependencies        = $this->get_dependency_filepaths();
-		$plugin_dependencies = $this->plugins[ $plugin_file ]['RequiresPlugins'];
+		$dependencies          = $this->get_dependency_filepaths();
+		$plugin_dependencies   = $this->plugins[ $plugin_file ]['RequiresPlugins'];
 		// $circular_dependencies = $this->get_circular_dependencies();
 		// if ( in_array( $plugin_file, $circular_dependencies, true ) ) {
-		// return $actions;
+		// 	return $actions;
 		// }
-		foreach ( $plugin_dependencies as $plugin_dependency ) {
-			if ( isset( $actions['activate'] ) ) {
-				if ( ! $dependencies[ $plugin_dependency ] || is_plugin_inactive( $dependencies[ $plugin_dependency ] ) ) {
-					$actions['activate']     = __( 'Cannot Activate' );
-					$actions['dependencies'] = sprintf(
-					/* translators: 1: opening tag link to Dependencies tab 2: closing tag */
-						__( '%1$sDependencies%2$s' ),
-						'<a href=' . esc_url( network_admin_url( 'plugin-install.php?tab=dependencies' ) ) . '>',
-						'</a>'
-					);
-					add_action( 'after_plugin_row_' . $plugin_file, array( $this, 'hide_column_checkbox' ), 10, 1 );
-					break;
-				}
+
+		if ( ! isset( $actions['activate'] ) ) {
+			return $actions;
+		}
+
+		foreach ( $plugin_dependencies as $plugin_dependency ) {		
+			if ( ! $dependencies[ $plugin_dependency ] || is_plugin_inactive( $dependencies[ $plugin_dependency ] ) ) {
+				$actions['activate']     = __( 'Cannot Activate' );
+				$actions['dependencies'] = sprintf(
+				/* translators: 1: opening tag link to Dependencies tab 2: closing tag */
+					__( '%1$sDependencies%2$s' ),
+					'<a href=' . esc_url( network_admin_url( 'plugin-install.php?tab=dependencies' ) ) . '>',
+					'</a>'
+				);
+				add_action( 'after_plugin_row_' . $plugin_file, array( $this, 'hide_column_checkbox' ), 10, 1 );
+				break;
 			}
 		}
 

--- a/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -448,6 +448,7 @@ class WP_Plugin_Dependencies {
 		$dependencies          = $this->get_dependency_filepaths();
 		$plugin_dependencies   = $this->plugins[ $plugin_file ]['RequiresPlugins'];
 		// $circular_dependencies = $this->get_circular_dependencies();
+		
 		// if ( in_array( $plugin_file, $circular_dependencies, true ) ) {
 		// 	return $actions;
 		// }

--- a/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -457,8 +457,8 @@ class WP_Plugin_Dependencies {
 			return $actions;
 		}
 
-		foreach ( $plugin_dependencies as $plugin_dependency ) {		
-			if ( ! $dependencies[ $plugin_dependency ] || is_plugin_inactive( $dependencies[ $plugin_dependency ] ) ) {
+		foreach ( $plugin_dependencies as $plugin_dependency ) {
+			if ( ! isset( $dependencies[ $plugin_dependency ] ) || is_plugin_active( $dependencies[ $plugin_dependency ] ) ) {
 				$actions['activate']     = __( 'Cannot Activate' );
 				$actions['dependencies'] = sprintf(
 					/* translators: 1: Opening link tag to the Dependencies tab, 2: Closing link tag. */


### PR DESCRIPTION
This PR:
- [x] Inverts an `isset()` call and makes it a guard to reduce nesting.
- [x] Aligns and makes the `translators` comment meet documentation standards.
- [x] Adds some spacing around the circular dependency guard for readability.
- [x] Changes a falsy check on an array to `! isset()` to cover the possibility of a missing key.
- [x] Adds a `@return` description for consistency with WordPress Core.