### PR TITLE
Various improvements to `::unset_action_links()`.

### DIFF
--- a/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -417,7 +417,7 @@ class WP_Plugin_Dependencies {
 	 * @param array  $actions     Action links.
 	 * @param string $plugin_file Plugin file.
 	 *
-	 * @return array
+	 * @return array Plugin action links after checking for an active requiring plugin.
 	 */
 	public function unset_action_links( $actions, $plugin_file ) {
 		foreach ( $this->requires_plugins as $plugin => $requires ) {

--- a/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -423,12 +423,7 @@ class WP_Plugin_Dependencies {
 		foreach ( $this->requires_plugins as $plugin => $requires ) {
 			$dependents = explode( ',', $requires['RequiresPlugins'] );
 			if ( is_plugin_active( $plugin ) && in_array( dirname( $plugin_file ), $dependents, true ) ) {
-				if ( isset( $actions['delete'] ) ) {
-					unset( $actions['delete'] );
-				}
-				if ( isset( $actions['deactivate'] ) ) {
-					unset( $actions['deactivate'] );
-				}
+				unset( $actions['delete'], $actions['deactivate'] );
 			}
 		}
 


### PR DESCRIPTION
This PR:

- [x] Removes two `isset()` calls and merges two `unset()` calls.
  - [unset()](https://www.php.net/manual/en/function.unset.php) supports multiple arguments and does not care if the value currently exists.
- [x] Adds a `@return` description for consistency with WordPress Core.