### PR TITLE
Various improvements to `::modify_plugin_row_elements_requires()`.

### DIFF
--- a/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -387,7 +387,7 @@ class WP_Plugin_Dependencies {
 			return;
 		}
 
-		$links = $this->get_view_details_link( $plugin_file, $names );
+		$links = $this->get_view_details_links( $plugin_file, $names );
 
 		print '<script>';
 		print 'jQuery("tr[data-plugin=\'' . esc_attr( $plugin_file ) . '\'] .plugin-version-author-uri").append("<br><br><strong>' . esc_html__( 'Requires:' ) . '</strong> ' . wp_kses_post( $links ) . '");';

--- a/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -387,9 +387,10 @@ class WP_Plugin_Dependencies {
 			return;
 		}
 
-		$names = $this->get_view_details_link( $plugin_file, $names );
+		$links = $this->get_view_details_link( $plugin_file, $names );
+
 		print '<script>';
-		print 'jQuery("tr[data-plugin=\'' . esc_attr( $plugin_file ) . '\'] .plugin-version-author-uri").append("<br><br><strong>' . esc_html__( 'Requires:' ) . '</strong> ' . wp_kses_post( $names ) . '");';
+		print 'jQuery("tr[data-plugin=\'' . esc_attr( $plugin_file ) . '\'] .plugin-version-author-uri").append("<br><br><strong>' . esc_html__( 'Requires:' ) . '</strong> ' . wp_kses_post( $links ) . '");';
 		print '</script>';
 	}
 

--- a/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -382,12 +382,15 @@ class WP_Plugin_Dependencies {
 	 */
 	public function modify_plugin_row_elements_requires( $plugin_file ) {
 		$names = $this->get_requires_plugins_names( $plugin_file );
-		if ( ! empty( $names ) ) {
-			$names = $this->get_view_details_links( $plugin_file, $names );
-			print '<script>';
-			print 'jQuery("tr[data-plugin=\'' . esc_attr( $plugin_file ) . '\'] .plugin-version-author-uri").append("<br><br><strong>' . esc_html__( 'Requires:' ) . '</strong> ' . wp_kses_post( $names ) . '");';
-			print '</script>';
+
+		if ( empty( $names ) ) {
+			return;
 		}
+
+		$names = $this->get_view_details_link( $plugin_file, $names );
+		print '<script>';
+		print 'jQuery("tr[data-plugin=\'' . esc_attr( $plugin_file ) . '\'] .plugin-version-author-uri").append("<br><br><strong>' . esc_html__( 'Requires:' ) . '</strong> ' . wp_kses_post( $names ) . '");';
+		print '</script>';
 	}
 
 	/**


### PR DESCRIPTION
This PR:

- [x] Inverts an `empty()` check and converts it to a guard to reduce nesting.
- [x] Renames a duplicate `$names` variable to `$links` and adds spacing for readability.