### PR TITLE
Various improvements to `::get_view_details_link()`.

### DIFF
--- a/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -388,19 +388,8 @@ class WP_Plugin_Dependencies {
 		foreach ( $dependencies as $dependency ) {
 			$plugin_data = $this->plugin_data[ $dependency ];
 			foreach ( $names_arr as $name ) {
-				if ( $name === $plugin_data['name'] ) {
-					if ( empty( $plugin_data['version'] ) ) {
-						$details_links[ $name ] = $name;
-					} else {
-						$details_links[ $name ] = sprintf(
-							"<a href='%s' class='thickbox open-plugin-details-modal' aria-label='%s' data-title='%s'>%s</a>",
-							network_admin_url( 'plugin-install.php?tab=plugin-information&plugin=' . $plugin_data['slug'] . '&TB_iframe=true&width=600&height=550' ),
-							/* translators: %s: Plugin name. */
-							sprintf( __( 'More information about %s' ), $name ),
-							$name,
-							$name
-						);
-					}
+				if ( $name !== $plugin_data['name'] ) {
+					continue;
 				}
 			}
 		}

--- a/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -391,6 +391,11 @@ class WP_Plugin_Dependencies {
 				if ( $name !== $plugin_data['name'] ) {
 					continue;
 				}
+
+				if ( empty( $plugin_data['version'] ) ) {
+					$details_links[ $name ] = $name;
+					continue;
+				}
 			}
 		}
 

--- a/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -364,7 +364,7 @@ class WP_Plugin_Dependencies {
 	public function modify_plugin_row_elements_requires( $plugin_file ) {
 		$names = $this->get_requires_plugins_names( $plugin_file );
 		if ( ! empty( $names ) ) {
-			$names = $this->get_view_details_link( $plugin_file, $names );
+			$names = $this->get_view_details_links( $plugin_file, $names );
 			print '<script>';
 			print 'jQuery("tr[data-plugin=\'' . esc_attr( $plugin_file ) . '\'] .plugin-version-author-uri").append("<br><br><strong>' . esc_html__( 'Requires:' ) . '</strong> ' . wp_kses_post( $names ) . '");';
 			print '</script>';
@@ -379,7 +379,7 @@ class WP_Plugin_Dependencies {
 	 *
 	 * @return string 'View details' like links for required plugins.
 	 */
-	private function get_view_details_link( $plugin_file, $names ) {
+	private function get_view_details_links( $plugin_file, $names ) {
 		$details_links = array();
 		$names_arr     = explode( ', ', $names );
 		$dependencies  = $this->requires_plugins[ $plugin_file ]['RequiresPlugins'];

--- a/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -397,9 +397,9 @@ class WP_Plugin_Dependencies {
 					continue;
 				}
 				
-				$url                    = network_admin_url( 'plugin-install.php?tab=plugin-information&plugin=' . $plugin_data['slug'] . '&TB_iframe=true&width=600&height=550' );
 				$details_links[ $name ] = sprintf(
 					'<a href="%s" class="thickbox open-plugin-details-modal" aria-label="%s" data-title="%s">%s</a>',
+					esc_url( network_admin_url( 'plugin-install.php?tab=plugin-information&plugin=' . $plugin_data['slug'] . '&TB_iframe=true&width=600&height=550' ) ),
 					/* translators: %s: Plugin name. */
 					sprintf( __( 'More information about %s' ), esc_attr( $name ) ),
 					$name

--- a/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -377,7 +377,7 @@ class WP_Plugin_Dependencies {
 	 * @param string $plugin_file Plugin file name.
 	 * @param string $names       Names of required plugins.
 	 *
-	 * @return string
+	 * @return string 'View details' like links for required plugins.
 	 */
 	private function get_view_details_link( $plugin_file, $names ) {
 		$details_links = array();

--- a/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -396,6 +396,14 @@ class WP_Plugin_Dependencies {
 					$details_links[ $name ] = $name;
 					continue;
 				}
+				
+				$url                    = network_admin_url( 'plugin-install.php?tab=plugin-information&plugin=' . $plugin_data['slug'] . '&TB_iframe=true&width=600&height=550' );
+				$details_links[ $name ] = sprintf(
+					'<a href="%s" class="thickbox open-plugin-details-modal" aria-label="%s" data-title="%s">%s</a>',
+					/* translators: %s: Plugin name. */
+					sprintf( __( 'More information about %s' ), esc_attr( $name ) ),
+					$name
+				);
 			}
 		}
 


### PR DESCRIPTION
This PR:

- [x] Inverts a check on `$name` and converts it to a guard to reduce nesting.
- [x] Uses `continue` to further reduce nesting.
- [x] Escapes the `$name` variable when used in HTML attributes.
- [x] Escapes the URL, which is now stored in `$url` to improve readability after this change.
- [x] Adds a `@return` description for consistency with WordPress Core.
- [x] Renames the method to `get_view_details_links()` for accuracy, as this method can return multiple links as a single string.