### PR TITLE
Check dependencies after installing plugin via "Add New".

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 [unreleased]
 * update _More details_ link
+* fixed strange error between slug from different sources
 
 #### 1.13.0 / 2023-07-10
 * update version check

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,6 +10,7 @@
     <exclude-pattern>*/node_modules/*</exclude-pattern>
     <exclude-pattern>*/tests/*</exclude-pattern>
     <exclude-pattern>*/test-plugins/*</exclude-pattern>
+    <exclude-pattern>*.js</exclude-pattern>
 
     <rule ref="WordPress-Core">
         <exclude name="WordPress.Files.FileName.InvalidClassFileName" />

--- a/plugin.php
+++ b/plugin.php
@@ -79,9 +79,6 @@ class Init {
 			}
 		);
 
-		// Switch to simple plugin card.
-		add_filter( 'pd_simple_card', '__return_true' );
-
 		if ( ! WP_PLUGIN_DEPENDENCIES1_COMMITTED ) {
 			require_once __DIR__ . '/wp-admin/includes/class-wp-plugin-dependencies.php';
 

--- a/plugin.php
+++ b/plugin.php
@@ -13,7 +13,7 @@
  * Plugin URI:  https://wordpress.org/plugins/wp-plugin-dependencies
  * Description: Parses 'Requires Plugins' header, add plugin install dependencies tab, and information about dependencies.
  * Author: Andy Fragen, Colin Stewart, Paul Biron
- * Version: 1.13.0.1
+ * Version: 1.13.0.2
  * License: MIT
  * Network: true
  * Requires at least: 6.0

--- a/wp-admin/includes/class-wp-plugin-dependencies-2.php
+++ b/wp-admin/includes/class-wp-plugin-dependencies-2.php
@@ -146,7 +146,7 @@ class WP_Plugin_Dependencies_2 {
 	 * @return array
 	 */
 	public function upgrader_package_options( $options ) {
-		$options['hook_extra']['slug'] = $this->args->slug;
+		$options['hook_extra']['slug'] = $options['hook_extra']['temp_backup']['slug'];
 		remove_filter( 'upgrader_package_options', array( $this, 'upgrader_package_options' ), 10 );
 
 		return $options;

--- a/wp-admin/includes/class-wp-plugin-dependencies-2.php
+++ b/wp-admin/includes/class-wp-plugin-dependencies-2.php
@@ -146,7 +146,11 @@ class WP_Plugin_Dependencies_2 {
 	 * @return array
 	 */
 	public function upgrader_package_options( $options ) {
-		$options['hook_extra']['slug'] = $options['hook_extra']['temp_backup']['slug'];
+		if ( isset( $options['hook_extra']['temp_backup'] ) ) {
+			$options['hook_extra']['slug'] = $options['hook_extra']['temp_backup']['slug'];
+		} else {
+			$options['hook_extra']['slug'] = $this->args->slug;
+		}
 		remove_filter( 'upgrader_package_options', array( $this, 'upgrader_package_options' ), 10 );
 
 		return $options;

--- a/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -318,7 +318,7 @@ final class WP_Plugin_Dependencies {
 	public function get_dot_org_data() {
 		global $pagenow;
 
-		if ( ! in_array( $pagenow, array( 'plugin-install.php', 'plugins.php' ), true ) ) {
+		if ( ! wp_doing_ajax() && ! in_array( $pagenow, array( 'plugin-install.php', 'plugins.php' ), true ) ) {
 			return;
 		}
 

--- a/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -1105,13 +1105,20 @@ final class WP_Plugin_Dependencies {
 		}
 
 		if ( ! empty( $inactive_dependencies ) ) {
+			$inactive_dependency_names = array_map(
+				function( $dependency ) {
+					return $this->plugin_data[ $dependency ]['name'];
+				},
+				$inactive_dependencies
+			);
+
 			$status['errorCode']    = 'inactive_dependencies';
 			$status['errorMessage'] = sprintf(
-				/* translators: %s: A list of inactive dependency plugin slugs. */
+				/* translators: %s: A list of inactive dependency plugin names. */
 				__( 'The following plugins must be activated first: %s.' ),
-				implode( ', ', $inactive_dependencies )
+				implode( ', ', $inactive_dependency_names )
 			);
-			$status['errorData'] = $inactive_dependencies;
+			$status['errorData'] = array_combine( $inactive_dependencies, $inactive_dependency_names );
 
 			wp_send_json_error( $status );
 		}

--- a/wp-admin/includes/class-wp-plugin-dependencies.php
+++ b/wp-admin/includes/class-wp-plugin-dependencies.php
@@ -96,6 +96,7 @@ final class WP_Plugin_Dependencies {
 
 			add_action( 'admin_init', array( $this, 'modify_plugin_row' ), 15 );
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
+			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 			add_action( 'admin_notices', array( $this, 'admin_notices' ) );
 			add_action( 'network_admin_notices', array( $this, 'admin_notices' ) );
 		}
@@ -123,6 +124,28 @@ final class WP_Plugin_Dependencies {
 				plugins_url( 'wp-admin/css/wp-plugin-dependencies.css', 'wp-plugin-dependencies/plugin.php' ),
 				array(),
 				$wp_version
+			);
+		}
+	}
+
+	/**
+	 * Enqueues scripts for plugin dependencies on the "Add New" plugins screen.
+	 *
+	 * @global string $wp_version The WordPress version string.
+	 * @global string $pagenow    The filename of the current screen.
+	 *
+	 * @return void
+	 */
+	public function enqueue_scripts() {
+		global $wp_version, $pagenow;
+
+		if ( 'plugin-install.php' === $pagenow ) {
+			wp_enqueue_script(
+				'wp-plugin-dependencies-updates',
+				plugins_url( 'wp-admin/js/updates.js', 'wp-plugin-dependencies/plugin.php' ),
+				array( 'updates' ),
+				$wp_version,
+				true
 			);
 		}
 	}

--- a/wp-admin/includes/plugin-install.php
+++ b/wp-admin/includes/plugin-install.php
@@ -55,10 +55,6 @@ function wp_get_plugin_action_button( $name, $data, $compatible_php, $compatible
 	$all_plugin_dependencies_installed = $installed_plugin_dependencies_count === $plugin_dependencies_count;
 	$all_plugin_dependencies_active    = $active_plugin_dependencies_count === $plugin_dependencies_count;
 
-	if ( apply_filters( 'pd_simple_card', false ) ) {
-		$plugin_dependency_met = true;
-	}
-
 	sprintf(
 		'<a class="install-now button" data-slug="%s" href="%s" aria-label="%s" data-name="%s">%s</a>',
 		esc_attr( $data->slug ),

--- a/wp-admin/js/updates.js
+++ b/wp-admin/js/updates.js
@@ -29,45 +29,45 @@
 				wp.updates.ajax(
 					'check_plugin_dependencies',
 					{
-						slug: response.slug,
-						success: function() {
-							// Transform the 'Install' button into an 'Activate' button.
-							$message.removeClass( 'install-now installed button-disabled updated-message' )
-							.addClass( 'activate-now button-primary' )
-							.attr( 'href', response.activateUrl );
+							slug: response.slug,
+							success: function() {
+								// Transform the 'Install' button into an 'Activate' button.
+								$message.removeClass( 'install-now installed button-disabled updated-message' )
+								.addClass( 'activate-now button-primary' )
+								.attr( 'href', response.activateUrl );
 
-							if ( 'plugins-network' === pagenow ) {
-								$message
+								if ( 'plugins-network' === pagenow ) {
+									$message
 									.attr(
 										'aria-label',
 										sprintf(
-											/* translators: %s: Plugin name. */
+										/* translators: %s: Plugin name. */
 											_x( 'Network Activate %s', 'plugin' ),
 											response.pluginName
 										)
 									)
-									.text( __( 'Network Activate' ) );
-							} else {
-								$message
+									  .text( __( 'Network Activate' ) );
+								} else {
+									$message
 									.attr(
 										'aria-label',
 										sprintf(
-											/* translators: %s: Plugin name. */
+										/* translators: %s: Plugin name. */
 											_x( 'Activate %s', 'plugin' ),
 											response.pluginName
 										)
 									)
 									.text( __( 'Activate' ) );
-							}
-						},
-						error: function( error ) {
-							$message
+								}
+							},
+							error: function( error ) {
+								$message
 								.removeClass( 'install-now installed updated-message' )
 								.addClass( 'activate-now button-primary' )
 								.attr(
 									'aria-label',
 									sprintf(
-										/* translators: 1: Plugin name, 2. The reason the plugin cannot be activated. */
+									/* translators: 1: Plugin name, 2. The reason the plugin cannot be activated. */
 										_x( 'Cannot activate %1$s. %2$s', 'plugin' ),
 										response.pluginName,
 										error.errorMessage

--- a/wp-admin/js/updates.js
+++ b/wp-admin/js/updates.js
@@ -1,0 +1,83 @@
+(function( $, wp ) {
+    var $document = $( document ),
+		__ = wp.i18n.__,
+		_x = wp.i18n._x,
+		sprintf = wp.i18n.sprintf;
+
+    wp.updates.installPluginSuccess = function( response ) {
+		var $message = $( '.plugin-card-' + response.slug ).find( '.install-now' );
+
+		$message
+			.removeClass( 'updating-message' )
+			.addClass( 'updated-message installed button-disabled' )
+			.attr(
+				'aria-label',
+				sprintf(
+					/* translators: %s: Plugin name and version. */
+					_x( '%s installed!', 'plugin' ),
+					response.pluginName
+				)
+			)
+			.text( _x( 'Installed!', 'plugin' ) );
+
+		wp.a11y.speak( __( 'Installation completed successfully.' ) );
+
+		$document.trigger( 'wp-plugin-install-success', response );
+
+		if ( response.activateUrl ) {
+			setTimeout( function() {
+				wp.updates.ajax(
+					'check_plugin_dependencies',
+					{
+						slug: response.slug,
+						success: function() {
+							// Transform the 'Install' button into an 'Activate' button.
+							$message.removeClass( 'install-now installed button-disabled updated-message' )
+							.addClass( 'activate-now button-primary' )
+							.attr( 'href', response.activateUrl );
+
+							if ( 'plugins-network' === pagenow ) {
+								$message
+									.attr(
+										'aria-label',
+										sprintf(
+											/* translators: %s: Plugin name. */
+											_x( 'Network Activate %s', 'plugin' ),
+											response.pluginName
+										)
+									)
+									.text( __( 'Network Activate' ) );
+							} else {
+								$message
+									.attr(
+										'aria-label',
+										sprintf(
+											/* translators: %s: Plugin name. */
+											_x( 'Activate %s', 'plugin' ),
+											response.pluginName
+										)
+									)
+									.text( __( 'Activate' ) );
+							}
+						},
+						error: function( error ) {
+							$message
+								.removeClass( 'install-now installed updated-message' )
+								.addClass( 'activate-now button-primary' )
+								.attr(
+									'aria-label',
+									sprintf(
+										/* translators: 1: Plugin name, 2. The reason the plugin cannot be activated. */
+										_x( 'Cannot activate %1$s. %2$s', 'plugin' ),
+										response.pluginName,
+										error.errorMessage
+									)
+								)
+								.text( __( 'Cannot Activate' ) );
+						}
+					}
+				);
+			}, 1000 );
+		}
+	};
+})( jQuery, window.wp, window._wpUpdatesSettings );


### PR DESCRIPTION
After installing a plugin via the "Add New" screen, the "Install Now" button changes to "Installed" then "Activate".

This PR checks whether the plugin has any inactive dependencies. If so, the "Install Now" button changes to "Installed" then "Cannot Activate".

For the feature plugin, a custom script is used which overwrites `wp.updates.installPluginSuccess()`. For a Core merge, the changes can be made directly in Core's `src/wp-admin/js/updates.js`, and the `admin_enqueue_scripts` hook can be removed in `WP_Plugin_Dependencies::start()`.

## Steps To Test
Open DevTools on the `Network` tab.

---

### Scenario 1: A plugin with no dependencies
1. From `Plugins > Add New`, install a plugin with no dependencies.

Expected results:
- The button should read "Activate".
- The `admin-ajax.php` response should indicate success.
- A `data: { slug, message }` entry should indicate that the plugin has no required plugins.

---

### Scenario 2: A plugin with no active dependencies
1. From `Plugins > Add New`, install a plugin with two dependencies (try searching `sso metadata`, for example).
2. From the plugin card, click "View details" on both dependencies and install them.
3. Wait about 10-30 seconds, then refresh the page. (I know. This is the next bit we need to handle.).
5. Now click "Install Now" on the dependent plugin.

Expected results:
- The button should  read "Cannot Activate".
- The `admin-ajax.php` response should indicate failure.
- A `data: { slug, errorCode, errorMessage, errorData }` entry should mention that both dependencies must be activated first.

---

### Scenario 3: A plugin with one active dependency
1. Delete the dependent plugin, but keep the dependencies.
2. Navigate to `Plugins > Installed plugins` and activate **one** of the dependencies.
3. Navigate back to the "Add New" screen.
4. Click "Install Now" on the dependent plugin.

Expected results:
- The button should  read "Cannot Activate".
- The `admin-ajax.php` response should indicate failure.
- A `data: { slug, errorCode, errorMessage, errorData }` entry should mention only the inactive dependency must be activated first.

---

### Scenario 4: A plugin with all its dependencies active
1. Delete the dependent plugin, but keep the dependencies.
2. Navigate to `Plugins > Installed plugins` and activate the remaining dependency.
3. Navigate back to the "Add New" screen.
4. Click "Install Now" on the dependent plugin.

Expected results:
- The button should read "Activate".
- The `admin-ajax.php` response should indicate success.
- A `data: { slug, message }` entry should indicate all required plugins are installed and activated.