### PR TITLE
Fix broken description width on certain screen sizes.

### DIFF
--- a/wp-admin/css/wp-plugin-dependencies.css
+++ b/wp-admin/css/wp-plugin-dependencies.css
@@ -47,7 +47,12 @@
 
 .plugin-card .desc > p {
 	margin-left: 148px;
-	margin-right: 128px;
+}
+
+@media (min-width: 1101px) {
+	.plugin-card .desc > p {
+		margin-right: 128px;
+	}
 }
 
 .plugin-card .plugin-dependencies {

--- a/wp-admin/css/wp-plugin-dependencies.css
+++ b/wp-admin/css/wp-plugin-dependencies.css
@@ -55,6 +55,12 @@
 	}
 }
 
+@media (min-width: 481px) and (max-width: 781px) {
+	.plugin-card .desc > p {
+		margin-right: 128px;
+	}
+}
+
 .plugin-card .plugin-dependencies {
 	background-color: #e5f5fa;
 	border-left: 3px solid #72aee6;


### PR DESCRIPTION
Fixes #47.

This ensures that the right margin is only added from `481px - 781px` and `>= 1101px` screen widths.